### PR TITLE
Expose listen-metrics-urls property

### DIFF
--- a/jobs/etcd/spec
+++ b/jobs/etcd/spec
@@ -40,7 +40,11 @@ consumes:
 properties:
   etcd.dns_suffix:
     description: If provided, used as a DNS suffix for all nodes in the etcd cluster
-  tls.etcd.ca:
+  etcd.metrics_protocol:
+    description: IF provided with etcd.metrics_port, metrics endpoints listen with the protocol. http or https.
+  etcd.metrics_port:
+    description: IF provided with etcd.metrics_protocol, metrics endpoints listen on the port. 2379 and 2380 can not be used.
+  tls.etcd.ca: 
     description: CA for etcd client and server authentication
   tls.etcd.certificate:
     description: Certificate for etcd client and server authentication

--- a/jobs/etcd/templates/bin/etcd.erb
+++ b/jobs/etcd/templates/bin/etcd.erb
@@ -50,4 +50,5 @@ fi
   --peer-client-cert-auth \
   --peer-trusted-ca-file="/var/vcap/jobs/etcd/config/peer-ca.crt" \
   --peer-cert-file="/var/vcap/jobs/etcd/config/peer.crt" \
-  --peer-key-file="/var/vcap/jobs/etcd/config/peer.key"
+  --peer-key-file="/var/vcap/jobs/etcd/config/peer.key" \
+<% if_p("etcd.metrics_protocol", "etcd.metrics_port") do |protocol, port| %>  --listen-metrics-urls=<%= protocol %>://0.0.0.0:<%= port %> \<% end %>

--- a/manifests/ops-files/change-metrics-url.yml
+++ b/manifests/ops-files/change-metrics-url.yml
@@ -1,0 +1,6 @@
+- type: replace
+  path: /instance_groups/name=etcd/jobs/name=etcd/properties/etcd?/metrics_protocol?
+  value: ((metrics_protocol))
+- type: replace
+  path: /instance_groups/name=etcd/jobs/name=etcd/properties/etcd?/metrics_port?
+  value: ((metrics_port))


### PR DESCRIPTION
This pr exposes `listen-metrics-urls` property in etcd so that operator can use a separate port and protocol for the metrics endpoint.

fixes #8 