### PR TITLE
Refactor bbr scripts to work for multi-master

### DIFF
--- a/jobs/bbr-etcd/spec
+++ b/jobs/bbr-etcd/spec
@@ -4,6 +4,9 @@ name: bbr-etcd
 templates:
   backup.erb: bin/bbr/backup
   restore.erb: bin/bbr/restore
+  metadata.sh.erb: bin/bbr/metadata
+  pre-restore-lock.sh.erb: bin/bbr/pre-restore-lock
+  post-restore-unlock.sh.erb: bin/bbr/post-restore-unlock
 
 packages: []
 

--- a/jobs/bbr-etcd/templates/backup.erb
+++ b/jobs/bbr-etcd/templates/backup.erb
@@ -1,12 +1,15 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
 source /var/vcap/jobs/etcd/bin/utils.sh
 
-BBR_ARTIFACT_FILE_PATH="${BBR_ARTIFACT_DIRECTORY}/snapshotdb"
-
+export BBR_ARTIFACT_FILE_PATH="${BBR_ARTIFACT_DIRECTORY}/snapshotdb"
 export ETCDCTL_API=3
+
+
+<% if spec.bootstrap %>
+echo "Taking etcd snapshot"
 
 /var/vcap/packages/etcd/bin/etcdctl \
   --cacert /var/vcap/jobs/etcd/config/etcdctl-ca.crt \
@@ -14,3 +17,4 @@ export ETCDCTL_API=3
   --key /var/vcap/jobs/etcd/config/etcdctl.key \
   --endpoints "${etcd_endpoint_address}" \
   snapshot save "${BBR_ARTIFACT_FILE_PATH}"
+<% end %>

--- a/jobs/bbr-etcd/templates/metadata.sh.erb
+++ b/jobs/bbr-etcd/templates/metadata.sh.erb
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+echo "---
+restore_name: cfcr-etcd-snapshot
+<% if spec.bootstrap %>
+backup_name: cfcr-etcd-snapshot
+<% end %>
+"

--- a/jobs/bbr-etcd/templates/post-restore-unlock.sh.erb
+++ b/jobs/bbr-etcd/templates/post-restore-unlock.sh.erb
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Starting etcd"
+
+/var/vcap/bosh/bin/monit start etcd
+
+output="$(/var/vcap/bosh/bin/monit summary | grep etcd)"
+timeout=0
+
+while [[ $output != *"running"* ]]
+do
+  if [ $timeout == 60 ]; then echo "Timed out starting etcd"; exit 1; fi
+  timeout=$((timeout + 1))
+
+  echo "waiting"
+  sleep 1
+
+  output="$(/var/vcap/bosh/bin/monit summary | grep etcd)"
+done
+
+echo "Etcd restored"

--- a/jobs/bbr-etcd/templates/pre-restore-lock.sh.erb
+++ b/jobs/bbr-etcd/templates/pre-restore-lock.sh.erb
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Stopping etcd"
+/var/vcap/bosh/bin/monit stop etcd
+
+output="$(/var/vcap/bosh/bin/monit summary | grep 'etcd')"
+timeout=0
+
+while [[ $output != *"not monitored" ]]
+do
+  if [ $timeout == 60 ]; then echo "Timed out stopping etcd"; exit 1; fi
+  timeout=$((timeout + 1))
+
+  echo "waiting"
+  sleep 1
+
+  output="$(/var/vcap/bosh/bin/monit summary | grep 'etcd')"
+done
+
+echo "Etcd stopped"
+
+echo "Deleting old etcd data"
+rm -rf /var/vcap/store/etcd

--- a/jobs/bbr-etcd/templates/restore.erb
+++ b/jobs/bbr-etcd/templates/restore.erb
@@ -1,26 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 
 source /var/vcap/jobs/etcd/bin/utils.sh
 
-exec 1>&2
-
 export BBR_ARTIFACT_FILE_PATH="${BBR_ARTIFACT_DIRECTORY}/snapshotdb"
 export ETCDCTL_API=3
 
-/var/vcap/bosh/bin/monit unmonitor etcd
-/var/vcap/jobs/bpm/bin/bpm stop etcd
-
-while /var/vcap/jobs/bpm/bin/bpm pid etcd; do
-    echo "Waiting for etcd to exit"
-    sleep 1
-done
-
-echo "Deleting old etcd data"
-rm -rf /var/vcap/store/etcd
-
 echo "Restoring etcd data"
+
 /var/vcap/packages/etcd/bin/etcdctl \
     snapshot restore ${BBR_ARTIFACT_FILE_PATH} \
     --name="<%= spec.id %>" \
@@ -29,8 +17,3 @@ echo "Restoring etcd data"
     --data-dir="/var/vcap/store/etcd"
 
 chown -R vcap:vcap /var/vcap/store/etcd
-
-echo "Starting etcd"
-/var/vcap/jobs/bpm/bin/bpm start etcd
-/var/vcap/bosh/bin/monit summary
-/var/vcap/bosh/bin/monit monitor etcd


### PR DESCRIPTION
Hello,

We have modified the bbr scripts to work for multi master. This involves using the `backup_name` and `restore_name` functionality in the `metadata.sh.erb` file. The output of this is that the bootstrap node produces the only non-empty artifact and they all restore from the same artifact.

We have not implemented BPM for these scripts, this could be a future enhancement. 

Thanks,
Jake & @MirahImage 