### PR TITLE
Make VM deletion check more explicit

### DIFF
--- a/jobs/etcd/templates/bin/drain.erb
+++ b/jobs/etcd/templates/bin/drain.erb
@@ -22,7 +22,13 @@ trap output_for_bosh EXIT
 
 export ETCDCTL_API=3
 
-if echo "${BOSH_JOB_NEXT_STATE}" | grep "\"persistent_disk\":0"; then
+if echo "${BOSH_JOB_NEXT_STATE}" | grep -q "\"persistent_disk\":0"; then
+    is_node_deleted=1
+else
+    is_node_deleted=0
+fi
+
+if [ $is_node_deleted -eq 1 ] ; then
   member_id="$(/var/vcap/jobs/etcd/bin/etcdctl member list | grep "<%= spec.id %>" | cut -d',' -f1)"
   /var/vcap/jobs/etcd/bin/etcdctl member remove "${member_id}"
 fi


### PR DESCRIPTION
This example is referenced in the official BOSH documentation for drain (see https://bosh.io/docs/drain/#environment-variables) so people are coming here for reference on how to add a VM deletion check to their drain scripts.

This PR does two things:
* make the check for VM deletion more explicit
* add a `-q` to grep to silence the positive path of the if condition (if carelessly copied, this might break drain scripts easily if different ways of stdout and stderr redirection are used)